### PR TITLE
Introduce validateSnsMessageWithSettings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work/
 *~
+dist-newstyle


### PR DESCRIPTION
This fixes an issue that we ran into while using `aws-sns-verify`. The messages were from SNS but couldn't be validated because the library was expecting an `http` URI scheme for the `SigningCertURL` field.

This is because [the valid scheme was hardcoded](https://hackage.haskell.org/package/aws-sns-verify-0.0.0.3/docs/src/Amazon.SNS.Verify.ValidURI.html#validScheme) and couldn't be configured.

This PR addresses introduces a `ValidationSettings` record that allows you to override this.