### PR TITLE
Return more specific errors from URI validation

### DIFF
--- a/tests/Amazon/SNS/Verify/ValidateSpec.hs
+++ b/tests/Amazon/SNS/Verify/ValidateSpec.hs
@@ -102,7 +102,7 @@ spec = around_ useCertServer $ do
                               "SynthesisTaskNotification { TaskId: 680a1f1b-f3ae-4474-aa8f-3b6dfe52e656, Status: COMPLETED }"
                         }
                 }
-      go `shouldReturn` Left (BadUri "http://attacker.com/evil.pem")
+      go `shouldReturn` Left (BadDomain "attacker.com")
 
     it "successfully validates an SNS subscription" $ do
       -- pendingWith "need valid subscription payload"


### PR DESCRIPTION
In testing a resolver update in an app that users this library, we're
getting error messages like,

```
BadUri "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-60eadc530605d63b8e62a523676ef735.pem"
```

This looks entirely valid to me, but the library currently returns
`BadUri` for 3 distinct validations, so breaking them up might help be
realize what's going on. Hopefully.
